### PR TITLE
Remove config variable default_app_id

### DIFF
--- a/lib/lita/handlers/deploygate.rb
+++ b/lib/lita/handlers/deploygate.rb
@@ -3,7 +3,6 @@ module Lita
     class Deploygate < Handler
       config :user_name, required: true
       config :api_key, required: true
-      config :default_app_id, required: true
       config :app_names
 
       route(


### PR DESCRIPTION
This variable is not used anywhere in the handler code, so it seems
unnecessary to require it to be defined in the Lita config.
